### PR TITLE
Add Windows platform support

### DIFF
--- a/profiles/windows-arm64.profile
+++ b/profiles/windows-arm64.profile
@@ -1,0 +1,8 @@
+include(default)
+
+[settings]
+os=Windows
+arch=armv8
+compiler=msvc
+compiler.version=194
+compiler.runtime=static

--- a/profiles/windows-x64.profile
+++ b/profiles/windows-x64.profile
@@ -1,0 +1,8 @@
+include(default)
+
+[settings]
+os=Windows
+arch=x86_64
+compiler=msvc
+compiler.version=194
+compiler.runtime=static


### PR DESCRIPTION
## Summary
- Add Conan profiles for windows-x64 and windows-arm64 (MSVC, static CRT)
- Add `buildWindows()` function to `build.sh` with Windows environment detection
- Normalize OpenSSL library names (`libssl.lib` -> `ssl.lib`) for CMake compatibility

## Test plan
- [ ] CI builds successfully on the `feature/windows-support` branch
- [ ] Verify Conan profile produces correct static `.lib` files on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)